### PR TITLE
Added 'sec-testing' team

### DIFF
--- a/teams.json
+++ b/teams.json
@@ -46,6 +46,12 @@
         "url": "https://gist.github.com/kotakanbe/e4232407b75e1ec584e7",
         "description": "究極のIT系技術情報収集用Slackチーム",
         "tag": ["Tech"]
+    },
+    {
+        "name": "sec-testing",
+        "url": "http://csrf.jp:3000/",
+        "description": "セキュリティテストの技術共有を目的としたコミュニティ",
+        "tag": ["Tech", "Security"]
     }
 
 ]


### PR DESCRIPTION
セキュリティテストの技術共有コミュニティ sec-testing の追加です。

詳しくは http://www.slideshare.net/muneakinishimura/owasp-testing-guide-58765388 にて告知されています。
