### PR TITLE
Add larachat-jp

### DIFF
--- a/teams.json
+++ b/teams.json
@@ -94,5 +94,11 @@
         "url": "https://slackin-phpusers-ja.herokuapp.com/",
         "description": "日本語で PHP 関連の話題を中心とした雑談をするための Slack チーム",
         "tag": ["PHP", "Web"]
+    },
+    {
+        "name": "larachat-jp",
+        "url": "mailto:larachat.jp@gmail.com",
+        "description": "Laravelの話ができる、魅惑の会員制チャットルーム",
+        "tag": ["PHP", "Web"]
     }
 ]


### PR DESCRIPTION
[Laravel](https://laravel.com)というPHPフレームワークのユーザーが集まる `larachat-jp` を追加しました。
(管理者によるメールでの招待タイプ)
- [Slack](https://larachat-jp.slack.com/)
