### PR TITLE
Samezi patch #2

### DIFF
--- a/teams.json
+++ b/teams.json
@@ -85,7 +85,7 @@
     },    
     {
         "name": "雑談Slack",
-        "url": "https://samezi-but.com/zdnj.html",
+        "url": "http://samezi-but.com/zdnj.html",
         "description": "仕事中にサボタージュして雑談することに特化したSlack Teamです",
         "tag": ["Tech", "Talk", "Sabotage"]
     },


### PR DESCRIPTION
雑談SlackのURLのプロトコルが間違っていたので修正しました。
もうしわけありませんがお願いします。
