### PR TITLE
Add GCPUG.

### DIFF
--- a/teams.json
+++ b/teams.json
@@ -274,5 +274,11 @@
         "url": "https://haskell.jp/blog/posts/2017/01-first.html",
         "description": "日本HaskellユーザーグループのためのSlackチーム",
         "tag": ["Haskell"]
+    },
+    {
+        "name": "GCPUG",
+	"url": "https://docs.google.com/forms/d/e/1FAIpQLScYxAGwuosFFNvH-5yOj-_p-pAKdqZpmM2cgKh9Q8Zu6531Bw/viewform",
+        "description": "Google Cloud Platform User GroupのSlackチーム",
+        "tag": ["google", "GCP"]
     }
 ]


### PR DESCRIPTION
[Google Cloud Platform User Group](https://gcpug.jp)のSlackを追加しました。よかったら取り込んでください！