### PR TITLE
Osaka.vimを削除

### DIFF
--- a/teams.json
+++ b/teams.json
@@ -264,12 +264,6 @@
         "tag": ["Emacs", "Editor", "Emacs Lisp"]
     },
     {
-        "name": "osaka-vim",
-        "url": "https://osaka-vim-slackin.herokuapp.com/",
-        "description": "Osaka.vimコミュニティのSlackチーム",
-        "tag": ["Vim", "Editor"]
-    },
-    {
         "name": "Haskell-jp",
         "url": "https://haskell.jp/blog/posts/2017/01-first.html",
         "description": "日本HaskellユーザーグループのためのSlackチーム",


### PR DESCRIPTION
Osaka.vimをvim-jp内に移行する話になりました。
その為削除させて頂きます!

![slack_-_osaka_vim](https://user-images.githubusercontent.com/147351/32032747-b5c1121c-ba43-11e7-9fbd-bd99274d0797.png)

related: #45 