### PR TITLE
関西Lispユーザ会 slack招待リンクの変更

### DIFF
--- a/teams.json
+++ b/teams.json
@@ -343,7 +343,7 @@
     },
     {
         "name": "kansai-lisp-users",
-        "url": "https://kansai-lisp-users.herokuapp.com/",
+        "url": "https://join.slack.com/t/kansai-lisp-users/shared_invite/zt-1fhcb2opf-AFSsK6GBE7flxk_prIB4Ng",
         "description": "大阪京都を中心に活動するLisp系プログラミング言語のコミュニティ関西Lispユーザ会のslackチームです。",
         "tag": ["lisp"]
     },


### PR DESCRIPTION
お世話になっております。

以前、当会のslaskワークスペースの情報を掲載していただいた関西Lispユーザ会のmyaosatoです。

当会の招待リンクが変更となりましたので、情報更新分のPRをお送りします。

どうぞ、よろしくおねがいします。
